### PR TITLE
Correct the name of job->clientFile to job->clientFiles in PHP

### DIFF
--- a/php/src/jobs.php
+++ b/php/src/jobs.php
@@ -24,7 +24,7 @@ class Job extends Entity
                              $default = '1', $recursive = True);
         $this->json_property('domain', 'Domain', $many = False,
                              $default = '1', $recursive = True);
-        $this->json_property('clientFile', 'File', $default = [],
+        $this->json_property('clientFiles', 'File', $default = [],
                              $many = true, $recursive = True);
     }
 }

--- a/php/src/order_helper.php
+++ b/php/src/order_helper.php
@@ -78,13 +78,13 @@
         $j->notes = $notes;
         $j->deadline = null;
 
-        $j->clientFile = [];
+        $j->clientFiles = [];
 
         foreach ($files as $info) {
             if ($info['size'] > 0) {
                 $f = new File_();
                 $f->from_php_info($info);
-                array_push($j->clientFile, $f);
+                array_push($j->clientFiles, $f);
             }
         }
 


### PR DESCRIPTION
SDK, which fixes a bug where files could not be uploaded with
orders.