### PR TITLE
Fix methods of Job in python SDK.

### DIFF
--- a/python/jobs.py
+++ b/python/jobs.py
@@ -170,7 +170,7 @@ class Job(sdk.python.entities.Entity):
         """
         assignment = None
         for assignment in self.assignments:
-            if assignment.supplier.id is user_id:
+            if assignment.supplier.id == user_id:
                 assignment = assignment
         return assignment
 
@@ -223,7 +223,7 @@ class Job(sdk.python.entities.Entity):
             assignment exists
         """
         for assignment in self.assignments:
-            if assignment.supplier.id is user_id and not assignment.archived:
+            if assignment.supplier.id == user_id and not assignment.archived:
                 return assignment
         return None
 


### PR DESCRIPTION
They where incorrectly using `is` when they should have been
using `==`. Worked by mistake on cpython with small numbers
due to the int cache.