### PR TITLE
New script template to render template scripts into

### DIFF
--- a/python/domains.py
+++ b/python/domains.py
@@ -256,12 +256,7 @@ class Domain(sdk.python.entities.Entity):
             return compile_template(template_file.read(), database)
 
     def get_template_scripts(self, database):
-        """ Return HTML content for the footers of public domain pages.
-
-            That will be the one from the theme, if there is one, otherwise
-            it will be the default. The caller is responsible for ensuring
-            that the active theme, and also its template is properly embedded.
-        """
+        """ Return a div with the template script rendered inside of it. """
         return compile_template(self.active_theme.scripts_template(),
                                 database,
                                 with_script=True)

--- a/python/domains.py
+++ b/python/domains.py
@@ -255,6 +255,17 @@ class Domain(sdk.python.entities.Entity):
         with open("sdk/python/util/templates/footer.html") as template_file:
             return compile_template(template_file.read(), database)
 
+    def get_template_scripts(self, database):
+        """ Return HTML content for the footers of public domain pages.
+
+            That will be the one from the theme, if there is one, otherwise
+            it will be the default. The caller is responsible for ensuring
+            that the active theme, and also its template is properly embedded.
+        """
+        return compile_template(self.active_theme.scripts_template(),
+                                database,
+                                with_script=True)
+
     def logo_url(self):
         """ Return the domain logo if there is one or else return the
             PLATFORM_MASCOT_ICON

--- a/python/themes.py
+++ b/python/themes.py
@@ -57,7 +57,6 @@ class Theme(sdk.python.entities.Entity):
         self.json_property(str, "header_compiled")
         self.json_property(str, "footer_template")
         self.json_property(str, "footer_compiled")
-        self.json_property(str, "template_scripts")
 
         self.json_property(str, "index_page_error")
         self.json_property(str, "invoices_page_error")

--- a/python/themes.py
+++ b/python/themes.py
@@ -57,6 +57,7 @@ class Theme(sdk.python.entities.Entity):
         self.json_property(str, "header_compiled")
         self.json_property(str, "footer_template")
         self.json_property(str, "footer_compiled")
+        self.json_property(str, "template_scripts")
 
         self.json_property(str, "index_page_error")
         self.json_property(str, "invoices_page_error")
@@ -116,6 +117,10 @@ class Theme(sdk.python.entities.Entity):
         """ Check whether this theme can be a valid activated theme """
         return self.main_css_status >= VALID_BUT_NOT_UPDATED and \
             self.email_css_status >= VALID_BUT_NOT_UPDATED
+
+    def scripts_template(self):
+        """ Returs an empty div for a script element to be rendered into """
+        return '<div></div>'
 
 
 class Themes(sdk.python.entities.Resource):


### PR DESCRIPTION
@DanielCollins I've modified your original code and added a new method to theme.py called scripts_template, which returns an empty div. scripts_template is then used in domains.get_template_scripts. Because domains.get_template_scripts is the last element on the page the component script is written into it.

This PR helps move component scripts out of the `<footer>` element and appends it to the bottom of the page.