### PR TITLE
Update to newer version of coverage that correctly computes coverage

### DIFF
--- a/python/requirements/dev.txt
+++ b/python/requirements/dev.txt
@@ -1,7 +1,7 @@
 astroid==1.5.3
 codecov==2.0.15
-coverage==4.4.1
-hypothesis==3.36.0
+coverage==5.0a3
+hypothesis==3.82.1
 mypy==0.540
 pycodestyle==2.3.1
 pydocstyle==2.1.1


### PR DESCRIPTION
even for python files that were not included.