### PR TITLE
add passing test for independence of different ts entity objects.

### DIFF
--- a/typescript/src/entities/category.test.ts
+++ b/typescript/src/entities/category.test.ts
@@ -37,3 +37,21 @@ test('can get and set product', () => {
   p1.categories = undefined;
   expect(p1.categories).toBe(undefined);
 });
+
+test('independence of entities', () => {
+  const merchi = new Merchi();
+  const c1 = new merchi.Category();
+  const c2 = new merchi.Category();
+  const p = new merchi.Product();
+  const name = "vMjssEhwpHtMT";
+  const products = [p];
+  c1.name = name;
+  c1.products = products;
+  expect(c1.name).toBe(name);
+  expect(c1.products).toBe(products);
+  expect(c1.isDirty).toBe(true);
+  // c2 is a different object, and therefore totally unnaffected
+  expect(c2.name).toBe(undefined);
+  expect(c2.products).toBe(undefined);
+  expect(c2.isDirty).toBe(false);
+});

--- a/typescript/src/entity.ts
+++ b/typescript/src/entity.ts
@@ -52,6 +52,10 @@ export class Entity {
   // maps json names like 'id' to information about that property
   protected propertiesMap: Map<string, PropertyInfo>;
 
+  public get isDirty(): boolean {
+    return this._isDirty;
+  }
+
   protected static property(jsonName: string, arrayType?: string) {
     return function (target: Entity, propertyKey: string) {
       let properties = Reflect.getMetadata(Entity.propertiesSetKey,


### PR DESCRIPTION
there are some possible ways to make entity definitions less verbose e.g.
using decorators, but there are also some wrong ways to do it that will cause
bad things to happen. this is a defence test against some of those bad things.