### PR TITLE
proposal for means of reducing number of lines of code needed to

### DIFF
--- a/typescript/src/entities/category.ts
+++ b/typescript/src/entities/category.ts
@@ -7,40 +7,11 @@ export class Category extends Entity {
   protected static pluralName: string = "categories";
 
   @Category.property("id")
-  private _id?: number;
-
-  get id(): number | undefined {
-    return this._id;
-  }
-
-  set id(newId: number | undefined) {
-    this._id = newId;
-    this.markDirty("id", newId);
-  }
+  public id?: number;
 
   @Category.property("name")
-  private _name?: string;
-
-  get name(): string | undefined {
-    return this._name;
-  }
-
-  set name(newName: string | undefined) {
-    this._name = newName;
-    this.markDirty("name", newName);
-  }
+  public name?: string;
 
   @Category.property("products", "Product")
-  private _products?: Array<Product> | undefined;
-
-  get products(): Array<Product> | undefined {
-    return this._products;
-  }
-
-  set products(newProducts: Array<Product> | undefined) {
-    this._products = newProducts;
-    this.checkSameSessionList(newProducts);
-    this.addBackObjectList(newProducts);
-    this.markDirty("products", newProducts);
-  }
+  public products?: Array<Product> | undefined;
 }

--- a/typescript/src/entities/domain.ts
+++ b/typescript/src/entities/domain.ts
@@ -6,26 +6,8 @@ export class Domain extends Entity {
   protected static pluralName: string = "domains";
 
   @Domain.property("id")
-  private _id?: number;
-
-  get id(): number | undefined {
-    return this._id;
-  }
-
-  set id(newId: number | undefined) {
-    this._id = newId;
-    this.markDirty("id", newId);
-  }
+  public id?: number;
 
   @Domain.property("domain")
-  private _domain?: string;
-
-  get domain(): string | undefined {
-    return this._domain;
-  }
-
-  set domain(newDomain: string | undefined) {
-    this._domain = newDomain;
-    this.markDirty("domain", newDomain);
-  }
+  public domain?: string;
 }

--- a/typescript/src/entities/product.ts
+++ b/typescript/src/entities/product.ts
@@ -8,54 +8,14 @@ export class Product extends Entity {
   protected static pluralName: string = "products";
 
   @Product.property("id")
-  private _id?: number;
-
-  get id(): number | undefined {
-    return this._id;
-  }
-
-  set id(newId: number | undefined) {
-    this._id = newId;
-    this.markDirty("id", newId);
-  }
+  public id?: number;
 
   @Product.property("name")
-  private _name?: string;
-
-  get name(): string | undefined {
-    return this._name;
-  }
-
-  set name(newName: string | undefined) {
-    this._name = newName;
-    this.markDirty("name", newName);
-  }
+  public name?: string;
 
   @Product.property("categories", "Category")
-  private _categories?: Array<Category>;
-
-  get categories(): Array<Category> | undefined {
-    return this._categories;
-  }
-
-  set categories(newCategories: Array<Category> | undefined) {
-    this._categories = newCategories;
-    this.checkSameSessionList(newCategories);
-    this.addBackObjectList(newCategories);
-    this.markDirty("categories", newCategories)
-  }
+  public categories?: Array<Category>;
 
   @Product.property("domain")
-  private _domain?: Domain;
-
-  get domain(): Domain | undefined {
-    return this._domain;
-  }
-
-  set domain(newDomain: Domain | undefined) {
-    this.checkSameSession(newDomain);
-    this._domain = newDomain;
-    this.addBackObject(newDomain);
-    this.markDirty("domain", newDomain)
-  }
+  public domain?: Domain;
 }

--- a/typescript/src/entity.ts
+++ b/typescript/src/entity.ts
@@ -100,6 +100,7 @@ interface PropertyInfo {
   type: Function;  // e.g. Number
   arrayType?: Entity;  // if type is an array, arrayType is the element type
   dirty: boolean;  // true if out of date with server
+  currentValue?: any;  // type is actually `this.type | undefined`
 }
 
 export class Entity {
@@ -175,6 +176,58 @@ export class Entity {
 
   constructor() {
     this.propertiesMap = this.makePropertiesMap();
+    this.setupProperties();
+  }
+
+  private setupProperties = () => {
+    const properties: any = {};
+    const makeSetSingle = (info: PropertyInfo) => {
+      const get = () => {
+        return info.currentValue;
+      };
+      const set = (newValue?: Entity) => {
+        this.checkSameSession(newValue);
+        info.currentValue = newValue;
+        this.addBackObject(newValue);
+        this.markDirty(info.property, newValue);
+      };
+      return { get: get,
+        set: set};
+    };
+    const makeSetScalar = (info: PropertyInfo) => {
+      const get = () => {
+        return info.currentValue;
+      };
+      const set = (newValue: any) => {
+        info.currentValue = newValue;
+        this.markDirty(info.property, newValue);
+      };
+      return { get: get,
+        set: set};
+    };
+    const makeSetArray = (info: PropertyInfo) => {
+      const get = () => {
+        return info.currentValue;
+      };
+      const set = (newValue?: Array<Entity>) => {
+        info.currentValue = newValue;
+        this.checkSameSessionList(newValue);
+        this.addBackObjectList(newValue);
+        this.markDirty(info.property, newValue);
+      };
+      return { get: get,
+        set: set}; 
+    };
+    for (const info of this.propertiesMap.values()) {
+      if (info.type.prototype instanceof Entity) {
+        properties[info.attribute] = makeSetSingle(info);
+      } else if (info.arrayType) {
+        properties[info.attribute] = makeSetArray(info);
+      } else {
+        properties[info.attribute] = makeSetScalar(info);
+      }
+    }
+    Object.defineProperties(this, properties);
   }
 
   public static get<T extends typeof Entity>(this: T, id: number,
@@ -417,7 +470,6 @@ export class Entity {
       const propertyInfo = this.propertiesMap.get(key);
       if (propertyInfo !== undefined) {
         propertyInfo.dirty = false;
-        const attributeName: string = propertyInfo.attribute;
         if (propertyInfo.arrayType) {
           const nestedName = (propertyInfo.arrayType as any).singularName;
           const array = [];
@@ -428,9 +480,16 @@ export class Entity {
             nested.fromJson(itemData);
             array.push(nested);
           }
-          (this as any)[attributeName] = array;
+          propertyInfo.currentValue = array;
+        } else if (propertyInfo.type.prototype instanceof Entity) {
+          const nested = new (propertyInfo.type as any)();
+          const nestedName = (propertyInfo.type as any).singularName;
+          const itemData: any = {};
+          itemData[nestedName] = value;
+          nested.fromJson(itemData);
+          propertyInfo.currentValue = nested;
         } else {
-          (this as any)[attributeName] = value;
+          propertyInfo.currentValue = value;
         }
       }
     }


### PR DESCRIPTION
define an attribute in typescript SDK.

internally, this dynamically attaches properties behind the back of the
type checker. it uses a lot of `any` type. but, externally, the attributes
are still properly typed.