### PR TITLE
Fixup the way the merchi object is bound to the entity classes.

### DIFF
--- a/typescript/src/entities/product.test.ts
+++ b/typescript/src/entities/product.test.ts
@@ -300,3 +300,11 @@ test('can serialise product to form data understood by backend', () => {
     ['domain-count', '1']];
   expect(Array.from((p.toFormData() as any).entries())).toEqual(correct);
 });
+
+test('cannot mix sessions', () => {
+  const m1 = new Merchi();
+  const p = new m1.Product();
+  const m2 = new Merchi();
+  const d = new m2.Domain();
+  expect(() => p.domain = d).toThrow();
+});

--- a/typescript/src/entity.ts
+++ b/typescript/src/entity.ts
@@ -112,8 +112,9 @@ export class Entity {
   protected static singularName: string;
   protected static pluralName: string;
 
-  // this will be set by the parent Merchi object
+  // these will be set by the parent Merchi object
   public merchi!: Merchi;
+  public static merchi: Merchi;
 
   public isDirty: boolean = false;
   // maps json names like 'id' to information about that property
@@ -174,7 +175,10 @@ export class Entity {
     return map;
   }
 
-  constructor() {
+  constructor(merchi?: Merchi) {
+    if (merchi) {
+      this.merchi = merchi;
+    }
     this.propertiesMap = this.makePropertiesMap();
     this.setupProperties();
   }
@@ -245,7 +249,7 @@ export class Entity {
     if (!(options && options.withRights)) {
       fetchOptions.query.push(['skip_rights', 'y']);
     }
-    return this.prototype.merchi.authenticatedFetch(resource, fetchOptions).
+    return this.merchi.authenticatedFetch(resource, fetchOptions).
       then((data: any) => {
         const result: InstanceType<T> = (new this()) as InstanceType<T>;
         result.fromJson(data);
@@ -399,7 +403,7 @@ export class Entity {
     if (!(options && options.withRights)) {
       fetchOptions.query.push(['skip_rights', 'y']);
     }
-    return this.prototype.merchi.authenticatedFetch(resource, fetchOptions).then((data: any) => {
+    return this.merchi.authenticatedFetch(resource, fetchOptions).then((data: any) => {
       const metadata = {canCreate: data.canCreate,
         available: data.available,
         count: data.count,
@@ -444,13 +448,14 @@ export class Entity {
   };
 
   private getEntityClass = (name: string) => {
+    if (name === undefined) {
+      return undefined;
+    }
     return (this.merchi as any)[name];
   }
 
   protected checkSameSession = (other?: Entity) => {
-    /* istanbul ignore next */
     if (other !== undefined && other.merchi !== this.merchi) {
-      /* istanbul ignore next */
       throw new Error('cannot mix objects from different sessions');
     }
   };
@@ -568,7 +573,7 @@ export class Entity {
         return;
       } else if (info.arrayType) {
         processArrayProperty(info, value);
-      } else if (info.type.prototype.merchi === this.merchi) {
+      } else if (info.type.prototype instanceof Entity) {
         processSingleEntityProperty(info, value);
       } else {
         processScalarProperty(info, value);

--- a/typescript/src/merchi.ts
+++ b/typescript/src/merchi.ts
@@ -12,9 +12,9 @@ import { getCookie } from './cookie';
 export interface Type<T, A extends any[]> extends
    Function { new(...args: A): T; }
 
-function cloneClass<T, A extends []>(original: Type<T, A>): Type<T, A> {
+function cloneClass<T, A extends []>(original: Type<T, A>, arg: any): Type<T, A> {
   // copy the constructor, but use the empty object as `this`
-  const copy = original.bind({});
+  const copy = original.bind({} , arg);
   // pick up any static members (this is shallow, the members are not copied)
   Object.assign(copy, original);
   return copy;
@@ -37,8 +37,8 @@ export class Merchi {
     }
     function setupClass(merchi: Merchi, cls: typeof Entity) {
       // copy, to prevent interference from other merchi sessions
-      const result = cloneClass(cls) as typeof Entity;
-      result.prototype.merchi = merchi;
+      const result = cloneClass(cls, merchi) as typeof Entity;
+      result.merchi = merchi;
       return result;
     }
     // re-export configured versions of all classes


### PR DESCRIPTION
This permits more accurate types (less `any`), and also makes the
anti-session-mixing code actually work.