### PR TITLE
Hack around typescript limitation.

### DIFF
--- a/typescript/src/entities/address.ts
+++ b/typescript/src/entities/address.ts
@@ -12,28 +12,28 @@ export class Address extends Entity {
   protected static singularName: string = "address";
   protected static pluralName: string = "addresses";
 
-  @Address.property()
+  @Address.property({type: Date})
   public archived?: Date | null;
 
   @Address.property()
   public id?: number;
 
-  @Address.property()
+  @Address.property({type: String})
   public lineOne?: string | null;
 
-  @Address.property()
+  @Address.property({type: String})
   public lineTwo?: string | null;
 
-  @Address.property()
+  @Address.property({type: String})
   public city?: string | null;
 
-  @Address.property()
+  @Address.property({type: String})
   public state?: string | null;
 
-  @Address.property()
+  @Address.property({type: String})
   public country?: string | null;
 
-  @Address.property()
+  @Address.property({type: String})
   public postcode?: string | null;
 
   @Address.property({arrayType: "Shipment"})

--- a/typescript/src/entities/assignment.ts
+++ b/typescript/src/entities/assignment.ts
@@ -11,16 +11,16 @@ export class Assignment extends Entity {
   protected static singularName: string = "assignment";
   protected static pluralName: string = "assignments";
 
-  @Assignment.property()
+  @Assignment.property({type: Date})
   public archived?: Date | null;
 
   @Assignment.property()
   public id?: number;
 
-  @Assignment.property()
+  @Assignment.property({type: Date})
   public managerAccepts?: Date | null;
 
-  @Assignment.property()
+  @Assignment.property({type: Date})
   public supplierRefused?: Date | null;
 
   @Assignment.property()
@@ -29,22 +29,22 @@ export class Assignment extends Entity {
   @Assignment.property()
   public assignmentDeadline?: Date;
 
-  @Assignment.property()
+  @Assignment.property({type: 'Job'})
   public job?: Job | null;
 
-  @Assignment.property()
+  @Assignment.property({type: 'Job'})
   public supplyJob?: Job | null;
 
-  @Assignment.property()
+  @Assignment.property({type: User})
   public supplier?: User | null;
 
-  @Assignment.property()
+  @Assignment.property({type: Bid})
   public bid?: Bid | null;
 
   @Assignment.property({arrayType: "ProductionComment"})
   public comments?: Array<ProductionComment>;
 
-  @Assignment.property()
+  @Assignment.property({type: Shipment})
   public shipment?: Shipment | null;
 
   @Assignment.property({arrayType: "Notification"})

--- a/typescript/src/entities/bank.ts
+++ b/typescript/src/entities/bank.ts
@@ -7,7 +7,7 @@ export class Bank extends Entity {
   protected static singularName: string = "bank";
   protected static pluralName: string = "banks";
 
-  @Bank.property()
+  @Bank.property({type: Date})
   public archived?: Date | null;
 
   @Bank.property()
@@ -25,19 +25,19 @@ export class Bank extends Entity {
   @Bank.property()
   public accountName?: string;
 
-  @Bank.property()
+  @Bank.property({type: String})
   public bsb?: string | null;
 
-  @Bank.property()
+  @Bank.property({type: String})
   public swiftCode?: string | null;
 
-  @Bank.property()
+  @Bank.property({type: String})
   public iban?: string | null;
 
-  @Bank.property()
+  @Bank.property({type: String})
   public bankCode?: string | null;
 
-  @Bank.property()
+  @Bank.property({type: String})
   public bankAddress?: Address | null;
 
   @Bank.property()

--- a/typescript/src/entities/bid.ts
+++ b/typescript/src/entities/bid.ts
@@ -8,13 +8,13 @@ export class Bid extends Entity {
   protected static singularName: string = "bid";
   protected static pluralName: string = "bids";
 
-  @Bid.property()
+  @Bid.property({type: Date})
   public archived?: Date | null;
 
   @Bid.property()
   public id?: number;
 
-  @Bid.property()
+  @Bid.property({type: Date})
   public agreedDeadline?: Date | null;
 
   @Bid.property({arrayType: "BidItem"})

--- a/typescript/src/entities/bid_item.ts
+++ b/typescript/src/entities/bid_item.ts
@@ -6,7 +6,7 @@ export class BidItem extends Entity {
   protected static singularName: string = "bidItem";
   protected static pluralName: string = "bidItems";
 
-  @BidItem.property()
+  @BidItem.property({type: Date})
   public archived?: Date | null;
 
   @BidItem.property()
@@ -18,10 +18,10 @@ export class BidItem extends Entity {
   @BidItem.property()
   public quantity?: number;
 
-  @BidItem.property()
+  @BidItem.property({type: String})
   public description?: string | null;
 
-  @BidItem.property()
+  @BidItem.property({type: Number})
   public unitPrice?: number | null;
 
   @BidItem.property()

--- a/typescript/src/entities/cart.ts
+++ b/typescript/src/entities/cart.ts
@@ -11,7 +11,7 @@ export class Cart extends Entity {
   protected static singularName: string = "cart";
   protected static pluralName: string = "carts";
 
-  @Cart.property()
+  @Cart.property({type: Date})
   public archived?: Date | null;
 
   @Cart.property()
@@ -20,13 +20,13 @@ export class Cart extends Entity {
   @Cart.property()
   public creationDate?: Date;
 
-  @Cart.property()
+  @Cart.property({type: Date})
   public ip?: string | null;
 
-  @Cart.property()
+  @Cart.property({type: String})
   public token?: string | null;
 
-  @Cart.property()
+  @Cart.property({type: String})
   public receiverNotes?: string | null;
 
   @Cart.property()
@@ -50,19 +50,19 @@ export class Cart extends Entity {
   @Cart.property()
   public totalCost?: number;
 
-  @Cart.property()
+  @Cart.property({type: User})
   public client?: User | null;
 
-  @Cart.property()
+  @Cart.property({type: Company})
   public clientCompany?: Company | null;
 
   @Cart.property()
   public domain?: Domain;
 
-  @Cart.property()
+  @Cart.property({type: "Invoice"})
   public invoice?: Invoice | null;
 
-  @Cart.property()
+  @Cart.property({type: Address})
   public receiverAddress?: Address | null;
 
   @Cart.property({arrayType: "CartItem"})

--- a/typescript/src/entities/cart_item.ts
+++ b/typescript/src/entities/cart_item.ts
@@ -10,7 +10,7 @@ export class CartItem extends Entity {
   protected static singularName: string = "cartItem";
   protected static pluralName: string = "cartItems";
 
-  @CartItem.property()
+  @CartItem.property({type: Date})
   public archived?: Date | null;
 
   @CartItem.property()
@@ -19,7 +19,7 @@ export class CartItem extends Entity {
   @CartItem.property()
   public quantity?: number;
 
-  @CartItem.property()
+  @CartItem.property({type: String})
   public notes?: string | null;
 
   @CartItem.property()

--- a/typescript/src/entities/category.ts
+++ b/typescript/src/entities/category.ts
@@ -8,7 +8,7 @@ export class Category extends Entity {
   protected static singularName: string = "category";
   protected static pluralName: string = "categories";
 
-  @Category.property()
+  @Category.property({type: Date})
   public archived?: Date | null;
 
   @Category.property()

--- a/typescript/src/entities/company.ts
+++ b/typescript/src/entities/company.ts
@@ -19,7 +19,7 @@ export class Company extends Entity {
   protected static singularName: string = "company";
   protected static pluralName: string = "companies";
 
-  @Company.property()
+  @Company.property({type: Date})
   public archived?: Date | null;
 
   @Company.property()
@@ -28,34 +28,34 @@ export class Company extends Entity {
   @Company.property()
   public name?: string;
 
-  @Company.property()
+  @Company.property({type: String})
   public website?: string | null;
 
   @Company.property()
   public temporaryCreated?: boolean;
 
-  @Company.property()
+  @Company.property({type: String})
   public taxNumber?: string | null;
 
-  @Company.property()
+  @Company.property({type: Number})
   public taxNumberType?: number | null;
 
-  @Company.property()
+  @Company.property({type: String})
   public paypalAccount?: string | null;
 
-  @Company.property()
+  @Company.property({type: String})
   public paypalPassword?: string | null;
 
-  @Company.property()
+  @Company.property({type: String})
   public paypalSignature?: string | null;
 
   @Company.property()
   public isPaypalValid?: boolean;
 
-  @Company.property()
+  @Company.property({type: String})
   public stripePublishableKey?: string | null;
 
-  @Company.property()
+  @Company.property({type: String})
   public stripeApiKey?: string | null;
 
   @Company.property()
@@ -79,10 +79,10 @@ export class Company extends Entity {
   @Company.property()
   public country?: string;
 
-  @Company.property()
+  @Company.property({type: MerchiFile})
   public logo?: MerchiFile | null;
 
-  @Company.property()
+  @Company.property({type: CountryTax})
   public defaultTaxType?: CountryTax | null;
 
   @Company.property({arrayType: "EmailAddress"})

--- a/typescript/src/entities/company_invitation.ts
+++ b/typescript/src/entities/company_invitation.ts
@@ -7,7 +7,7 @@ export class CompanyInvitation extends Entity {
   protected static singularName: string = "companyInvitation";
   protected static pluralName: string = "companyInvitations";
 
-  @CompanyInvitation.property()
+  @CompanyInvitation.property({type: Date})
   public archived?: Date | null;
 
   @CompanyInvitation.property()

--- a/typescript/src/entities/component.ts
+++ b/typescript/src/entities/component.ts
@@ -7,7 +7,7 @@ export class Component extends Entity {
   protected static singularName: string = "component";
   protected static pluralName: string = "components";
 
-  @Component.property()
+  @Component.property({type: Date})
   public archived?: Date | null;
 
   @Component.property()
@@ -28,7 +28,7 @@ export class Component extends Entity {
   @Component.property({arrayType: "MerchiFile"})
   public images?: Array<MerchiFile>;
 
-  @Component.property()
+  @Component.property({type: MerchiFile})
   public featureImage?: MerchiFile | null;
 
   @Component.property({arrayType: "ComponentTag"})

--- a/typescript/src/entities/country_tax.ts
+++ b/typescript/src/entities/country_tax.ts
@@ -9,19 +9,19 @@ export class CountryTax extends Entity {
   protected static singularName: string = "countryTax";
   protected static pluralName: string = "countryTaxes";
 
-  @CountryTax.property()
+  @CountryTax.property({type: Date})
   public archived?: Date | null;
 
   @CountryTax.property()
   public id?: number;
 
-  @CountryTax.property()
+  @CountryTax.property({type: String})
   public country?: string | null;
 
   @CountryTax.property()
   public taxName?: string;
 
-  @CountryTax.property()
+  @CountryTax.property({type: Number})
   public taxPercent?: number | null;
 
   @CountryTax.property({arrayType: "Shipment"})

--- a/typescript/src/entities/discount.ts
+++ b/typescript/src/entities/discount.ts
@@ -6,7 +6,7 @@ export class Discount extends Entity {
   protected static singularName: string = "discount";
   protected static pluralName: string = "discounts";
 
-  @Discount.property()
+  @Discount.property({type: Date})
   public archived?: Date | null;
 
   @Discount.property()
@@ -18,7 +18,7 @@ export class Discount extends Entity {
   @Discount.property()
   public amount?: number;
 
-  @Discount.property()
+  @Discount.property({type: Product})
   public product?: Product | null;
 
   public discountedUnitCost = (product: Product) => {

--- a/typescript/src/entities/domain.ts
+++ b/typescript/src/entities/domain.ts
@@ -20,7 +20,7 @@ export class Domain extends Entity {
   protected static singularName: string = "domain";
   protected static pluralName: string = "domains";
 
-  @Domain.property()
+  @Domain.property({type: Date})
   public archived?: Date | null;
 
   @Domain.property()
@@ -56,25 +56,25 @@ export class Domain extends Entity {
   @Domain.property()
   public enableNotifications?: boolean;
 
-  @Domain.property()
+  @Domain.property({type: String})
   public conversionTrackingCode?: string | null;
 
-  @Domain.property()
+  @Domain.property({type: String})
   public newConversionTrackingCode?: string | null;
 
-  @Domain.property()
+  @Domain.property({type: String})
   public newGlobalTrackingCode?: string | null;
 
-  @Domain.property()
+  @Domain.property({type: String})
   public apiSecret?: string | null;
 
   @Domain.property()
   public company?: Company;
 
-  @Domain.property()
+  @Domain.property({type: MerchiFile})
   public logo?: MerchiFile | null;
 
-  @Domain.property()
+  @Domain.property({type: MerchiFile})
   public favicon?: MerchiFile | null;
 
   @Domain.property()

--- a/typescript/src/entities/domain_invitation.ts
+++ b/typescript/src/entities/domain_invitation.ts
@@ -7,7 +7,7 @@ export class DomainInvitation extends Entity {
   protected static singularName: string = "domainInvitation";
   protected static pluralName: string = "domainInvitations";
 
-  @DomainInvitation.property()
+  @DomainInvitation.property({type: Date})
   public archived?: Date | null;
 
   @DomainInvitation.property()
@@ -31,6 +31,6 @@ export class DomainInvitation extends Entity {
   @DomainInvitation.property()
   public sender?: User;
 
-  @DomainInvitation.property()
+  @DomainInvitation.property({type: Date})
   public user?: User | null;
 }

--- a/typescript/src/entities/draft.ts
+++ b/typescript/src/entities/draft.ts
@@ -10,22 +10,22 @@ export class Draft extends Entity {
   protected static singularName: string = "draft";
   protected static pluralName: string = "drafts";
 
-  @Draft.property()
+  @Draft.property({type: Date})
   public archived?: Date | null;
 
   @Draft.property()
   public id?: number;
 
-  @Draft.property()
+  @Draft.property({type: Date})
   public date?: Date | null;
 
-  @Draft.property()
+  @Draft.property({type: Date})
   public accepted?: Date | null;
 
-  @Draft.property()
+  @Draft.property({type: Date})
   public resendDate?: Date | null;
 
-  @Draft.property()
+  @Draft.property({type: Date})
   public viewed?: boolean | null;
 
   @Draft.property()

--- a/typescript/src/entities/draft_comment.ts
+++ b/typescript/src/entities/draft_comment.ts
@@ -10,13 +10,13 @@ export class DraftComment extends Entity {
   protected static singularName: string = "draftComment";
   protected static pluralName: string = "draftComments";
 
-  @DraftComment.property()
+  @DraftComment.property({type: Date})
   public archived?: Date | null;
 
   @DraftComment.property()
   public id?: number;
 
-  @DraftComment.property()
+  @DraftComment.property({type: Date})
   public date?: Date | null;
 
   @DraftComment.property()
@@ -37,7 +37,7 @@ export class DraftComment extends Entity {
   @DraftComment.property()
   public user?: User;
 
-  @DraftComment.property()
+  @DraftComment.property({type: MerchiFile})
   public file?: MerchiFile | null;
 
   @DraftComment.property({arrayType: "User"})
@@ -46,9 +46,9 @@ export class DraftComment extends Entity {
   @DraftComment.property({arrayType: "Notification"})
   public notifications?: Array<Notification>;
 
-  @DraftComment.property()
+  @DraftComment.property({type: Draft})
   public draft?: Draft | null;
 
-  @DraftComment.property()
+  @DraftComment.property({type: Job})
   public job?: Job | null;
 }

--- a/typescript/src/entities/email_address.ts
+++ b/typescript/src/entities/email_address.ts
@@ -7,7 +7,7 @@ export class EmailAddress extends Entity {
   protected static singularName: string = "emailAddress";
   protected static pluralName: string = "emailAddresses";
 
-  @EmailAddress.property()
+  @EmailAddress.property({type: EmailAddress})
   public archived?: Date | null;
 
   @EmailAddress.property()

--- a/typescript/src/entities/enrolled_domain.ts
+++ b/typescript/src/entities/enrolled_domain.ts
@@ -7,7 +7,7 @@ export class EnrolledDomain extends Entity {
   protected static singularName: string = "enrolledDomain";
   protected static pluralName: string = "enrolledDomains";
 
-  @EnrolledDomain.property()
+  @EnrolledDomain.property({type: Date})
   public archived?: Date | null;
 
   @EnrolledDomain.property()

--- a/typescript/src/entities/file.ts
+++ b/typescript/src/entities/file.ts
@@ -27,7 +27,7 @@ export class MerchiFile extends Entity {
     this.fileData = file;
   }
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: Date})
   public archived?: Date | null;
 
   @MerchiFile.property()
@@ -36,31 +36,31 @@ export class MerchiFile extends Entity {
   @MerchiFile.property()
   public uploadId?: string;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: String})
   public name?: string | null;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: String})
   public mimetype?: string | null;
 
   @MerchiFile.property()
   public size?: number;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: Date})
   public creationDate?: Date | null;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: String})
   public cachedViewUrl?: string | null;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: Date})
   public viewUrlExpires?: Date | null;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: String})
   public cachedDownloadUrl?: string | null;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: Date})
   public downloadUrlExpires?: Date | null;
 
-  @MerchiFile.property()
+  @MerchiFile.property({type: User})
   public uploader?: User | null;
 
   @MerchiFile.property()

--- a/typescript/src/entities/inventory.ts
+++ b/typescript/src/entities/inventory.ts
@@ -10,7 +10,7 @@ export class Inventory extends Entity {
   protected static singularName: string = "inventory";
   protected static pluralName: string = "inventories";
 
-  @Inventory.property()
+  @Inventory.property({type: Date})
   public archived?: Date | null;
 
   @Inventory.property()
@@ -28,7 +28,7 @@ export class Inventory extends Entity {
   @Inventory.property()
   public product?: Product;
 
-  @Inventory.property()
+  @Inventory.property({type: Address})
   public address?: Address | null;
 
   @Inventory.property({arrayType: "VariationsGroup"})

--- a/typescript/src/entities/inventory_unit_variation.ts
+++ b/typescript/src/entities/inventory_unit_variation.ts
@@ -7,7 +7,7 @@ export class InventoryUnitVariation extends Entity {
   protected static singularName: string = "inventoryUnitVariation";
   protected static pluralName: string = "inventoryUnitVariations";
 
-  @InventoryUnitVariation.property()
+  @InventoryUnitVariation.property({type: Date})
   public archived?: Date | null;
 
   @InventoryUnitVariation.property()

--- a/typescript/src/entities/invoice.ts
+++ b/typescript/src/entities/invoice.ts
@@ -19,19 +19,19 @@ export class Invoice extends Entity {
   protected static singularName: string = "invoice";
   protected static pluralName: string = "invoices";
 
-  @Invoice.property()
+  @Invoice.property({type: Date})
   public archived?: Date | null;
 
   @Invoice.property()
   public id?: number;
 
-  @Invoice.property()
+  @Invoice.property({type: Date})
   public creationDate?: Date | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Date})
   public paymentDeadline?: Date | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Date})
   public reminded?: Date | null;
 
   @Invoice.property()
@@ -40,28 +40,28 @@ export class Invoice extends Entity {
   @Invoice.property()
   public forceReminders?: boolean;
 
-  @Invoice.property()
+  @Invoice.property({type: String})
   public note?: string | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Date})
   public terms?: Date | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Number})
   public subtotalCost?: number | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Number})
   public taxAmount?: number | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Number})
   public totalCost?: number | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Boolean})
   public sendSms?: boolean | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Boolean})
   public sendEmail?: boolean | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Boolean})
   public unpaid?: boolean | null;
 
   @Invoice.property()
@@ -79,7 +79,7 @@ export class Invoice extends Entity {
   @Invoice.property()
   public acceptPhonePayment?: boolean;
 
-  @Invoice.property()
+  @Invoice.property({type: String})
   public invoiceToken?: string | null;
 
   @Invoice.property()
@@ -94,19 +94,19 @@ export class Invoice extends Entity {
   @Invoice.property({embeddedByDefault: false})
   public isCompletelyPaid?: boolean;
 
-  @Invoice.property()
+  @Invoice.property({type: User})
   public responsibleManager?: User | null;
 
-  @Invoice.property()
+  @Invoice.property({type: User})
   public creator?: User | null;
 
   @Invoice.property()
   public client?: User;
 
-  @Invoice.property()
+  @Invoice.property({type: Company})
   public clientCompany?: Company | null;
 
-  @Invoice.property()
+  @Invoice.property({type: Address})
   public shipping?: Address | null;
 
   @Invoice.property()
@@ -115,22 +115,22 @@ export class Invoice extends Entity {
   @Invoice.property({arrayType: "Item"})
   public items?: Array<Item>;
 
-  @Invoice.property()
+  @Invoice.property({type: MerchiFile})
   public pdf?: MerchiFile | null;
 
-  @Invoice.property()
+  @Invoice.property({type: MerchiFile})
   public receipt?: MerchiFile | null;
 
-  @Invoice.property()
+  @Invoice.property({type: PhoneNumber})
   public clientPhone?: PhoneNumber | null;
 
-  @Invoice.property()
+  @Invoice.property({type: EmailAddress})
   public clientEmail?: EmailAddress | null;
 
-  @Invoice.property()
+  @Invoice.property({type: PhoneNumber})
   public clientCompanyPhone?: PhoneNumber | null;
 
-  @Invoice.property()
+  @Invoice.property({type: EmailAddress})
   public clientCompanyEmail?: EmailAddress | null;
 
   @Invoice.property({arrayType: "DomainTag"})

--- a/typescript/src/entities/item.ts
+++ b/typescript/src/entities/item.ts
@@ -7,13 +7,13 @@ export class Item extends Entity {
   protected static singularName: string = "item";
   protected static pluralName: string = "items";
 
-  @Item.property()
+  @Item.property({type: Date})
   public archived?: Date | null;
 
   @Item.property()
   public id?: number;
 
-  @Item.property()
+  @Item.property({type: Number})
   public quantity?: number | null;
 
   @Item.property()
@@ -22,13 +22,13 @@ export class Item extends Entity {
   @Item.property()
   public cost?: number;
 
-  @Item.property()
+  @Item.property({type: Number})
   public taxAmount?: number | null;
 
-  @Item.property()
+  @Item.property({type: CountryTax})
   public taxType?: CountryTax | null;
 
-  @Item.property()
+  @Item.property({type: Invoice})
   public invoice?: Invoice | null;
 
   public totalCost = () => {

--- a/typescript/src/entities/job.ts
+++ b/typescript/src/entities/job.ts
@@ -25,7 +25,7 @@ export class Job extends Entity {
   protected static singularName: string = "job";
   protected static pluralName: string = "jobs";
 
-  @Job.property()
+  @Job.property({type: Date})
   public archived?: Date | null;
 
   @Job.property()
@@ -34,16 +34,16 @@ export class Job extends Entity {
   @Job.property()
   public quantity?: number;
 
-  @Job.property()
+  @Job.property({type: String})
   public notes?: string | null;
 
-  @Job.property()
+  @Job.property({type: String})
   public productionNotes?: string | null;
 
-  @Job.property()
+  @Job.property({type: Number})
   public productionStatus?: number | null;
 
-  @Job.property()
+  @Job.property({type: Number})
   public designStatus?: number | null;
 
   @Job.property()
@@ -61,13 +61,13 @@ export class Job extends Entity {
   @Job.property()
   public jobInfoApprovedByClient?: boolean;
 
-  @Job.property()
+  @Job.property({type: Number})
   public paymentStatus?: number | null;
 
-  @Job.property()
+  @Job.property({type: Date})
   public deductionDate?: Date | null;
 
-  @Job.property()
+  @Job.property({type: Number})
   public shippingStatus?: number | null;
 
   @Job.property()
@@ -76,10 +76,10 @@ export class Job extends Entity {
   @Job.property()
   public priority?: number;
 
-  @Job.property()
+  @Job.property({type: Number})
   public jobWeight?: number | null;
 
-  @Job.property()
+  @Job.property({type: Number})
   public jobVolume?: number | null;
 
   @Job.property()
@@ -94,16 +94,16 @@ export class Job extends Entity {
   @Job.property()
   public automaticPriceEnabled?: boolean;
 
-  @Job.property()
+  @Job.property({type: Number})
   public costPerUnit?: number | null;
 
-  @Job.property()
+  @Job.property({type: Number})
   public cost?: number | null;
 
-  @Job.property()
+  @Job.property({type: Number})
   public taxAmount?: number | null;
 
-  @Job.property()
+  @Job.property({type: Number})
   public totalCost?: number | null;
 
   @Job.property({embeddedByDefault: false})
@@ -136,25 +136,25 @@ export class Job extends Entity {
   @Job.property()
   public client?: User;
 
-  @Job.property()
+  @Job.property({type: User})
   public manager?: User | null;
 
-  @Job.property()
+  @Job.property({type: User})
   public designer?: User | null;
 
-  @Job.property()
+  @Job.property({type: Company})
   public clientCompany?: Company | null;
 
-  @Job.property()
+  @Job.property({type: PhoneNumber})
   public clientPhone?: PhoneNumber | null;
 
-  @Job.property()
+  @Job.property({type: EmailAddress})
   public clientEmail?: EmailAddress | null;
 
-  @Job.property()
+  @Job.property({type: PhoneNumber})
   public clientCompanyPhone?: PhoneNumber | null;
 
-  @Job.property()
+  @Job.property({type: EmailAddress})
   public clientCompanyEmail?: EmailAddress | null;
 
   @Job.property()
@@ -163,22 +163,22 @@ export class Job extends Entity {
   @Job.property({arrayType: "DraftComment"})
   public draftComments?: Array<DraftComment>;
 
-  @Job.property()
+  @Job.property({type: CountryTax})
   public taxType?: CountryTax | null;
 
   @Job.property({arrayType: "DomainTag"})
   public tags?: Array<DomainTag>;
 
-  @Job.property()
+  @Job.property({type: Address})
   public shipping?: Address | null;
 
-  @Job.property()
+  @Job.property({type: Address})
   public productionShippingAddress?: Address | null;
 
   @Job.property()
   public domain?: Domain;
 
-  @Job.property()
+  @Job.property({type: Invoice})
   public invoice?: Invoice | null;
 
   @Job.property({arrayType: "MerchiFile"})
@@ -187,10 +187,10 @@ export class Job extends Entity {
   @Job.property({arrayType: "MerchiFile"})
   public clientFiles?: Array<MerchiFile>;
 
-  @Job.property()
+  @Job.property({type: Shipment})
   public shipment?: Shipment | null;
 
-  @Job.property()
+  @Job.property({type: Inventory})
   public inventory?: Inventory | null;
 
   @Job.property({arrayType: "VariationsGroup"})
@@ -209,6 +209,7 @@ export class Job extends Entity {
   public supplyAssignment?: Assignment;
 
   @Job.property({arrayType: "Inventory",
+                 type: "Inventory",
                  embeddedByDefault: false})
   public matchingInventory?: Inventory | null;
 }

--- a/typescript/src/entities/job_comment.ts
+++ b/typescript/src/entities/job_comment.ts
@@ -9,13 +9,13 @@ export class JobComment extends Entity {
   protected static singularName: string = "jobComment";
   protected static pluralName: string = "jobComments";
 
-  @JobComment.property()
+  @JobComment.property({type: Date})
   public archived?: Date | null;
 
   @JobComment.property()
   public id?: number;
 
-  @JobComment.property()
+  @JobComment.property({type: Date})
   public date?: Date | null;
 
   @JobComment.property()
@@ -30,7 +30,7 @@ export class JobComment extends Entity {
   @JobComment.property()
   public urgency?: number;
 
-  @JobComment.property()
+  @JobComment.property({type: Date})
   public file?: MerchiFile | null;
 
   @JobComment.property({arrayType: "User"})

--- a/typescript/src/entities/menu.ts
+++ b/typescript/src/entities/menu.ts
@@ -7,7 +7,7 @@ export class Menu extends Entity {
   protected static singularName: string = "menu";
   protected static pluralName: string = "menus";
 
-  @Menu.property()
+  @Menu.property({type: Date})
   public archived?: Date | null;
 
   @Menu.property()

--- a/typescript/src/entities/menu_item.ts
+++ b/typescript/src/entities/menu_item.ts
@@ -6,7 +6,7 @@ export class MenuItem extends Entity {
   protected static singularName: string = "menuItem";
   protected static pluralName: string = "menuItems";
 
-  @MenuItem.property()
+  @MenuItem.property({type: Date})
   public archived?: Date | null;
 
   @MenuItem.property()

--- a/typescript/src/entities/notification.ts
+++ b/typescript/src/entities/notification.ts
@@ -16,7 +16,7 @@ export class Notification extends Entity {
   protected static singularName: string = "notification";
   protected static pluralName: string = "notifications";
 
-  @Notification.property()
+  @Notification.property({type: Date})
   public archived?: Date | null;
 
   @Notification.property()
@@ -40,10 +40,10 @@ export class Notification extends Entity {
   @Notification.property()
   public urgency?: number;
 
-  @Notification.property()
+  @Notification.property({type: String})
   public description?: string | null;
 
-  @Notification.property()
+  @Notification.property({type: String})
   public subject?: string | null;
 
   @Notification.property()
@@ -52,45 +52,45 @@ export class Notification extends Entity {
   @Notification.property()
   public htmlMessage?: string;
 
-  @Notification.property()
+  @Notification.property({type: String})
   public link?: string | null;
 
   @Notification.property()
   public section?: number;
 
-  @Notification.property()
+  @Notification.property({type: ShortUrl})
   public shortUrl?: ShortUrl | null;
 
   @Notification.property()
   public recipient?: User;
 
-  @Notification.property()
+  @Notification.property({type: User})
   public sender?: User | null;
 
-  @Notification.property()
+  @Notification.property({type: Job})
   public relatedJob?: Job | null;
 
-  @Notification.property()
+  @Notification.property({type: Draft})
   public relatedDraft?: Draft | null;
 
-  @Notification.property()
+  @Notification.property({type: Assignment})
   public relatedAssignment?: Assignment | null;
 
-  @Notification.property()
+  @Notification.property({type: Invoice})
   public relatedInvoice?: Invoice | null;
 
-  @Notification.property()
+  @Notification.property({type: JobComment})
   public relatedJobComment?: JobComment | null;
 
-  @Notification.property()
+  @Notification.property({type: DraftComment})
   public relatedDraftComment?: DraftComment | null;
 
-  @Notification.property()
+  @Notification.property({type: ProductionComment})
   public relatedProductionComment?: ProductionComment | null;
 
   @Notification.property()
   public domain?: Domain;
 
-  @Notification.property()
+  @Notification.property({type: MerchiFile})
   public attachment?: MerchiFile | null;
 }

--- a/typescript/src/entities/payment.ts
+++ b/typescript/src/entities/payment.ts
@@ -7,7 +7,7 @@ export class Payment extends Entity {
   protected static singularName: string = "payment";
   protected static pluralName: string = "payments";
 
-  @Payment.property()
+  @Payment.property({type: Date})
   public archived?: Date | null;
 
   @Payment.property()
@@ -31,9 +31,9 @@ export class Payment extends Entity {
   @Payment.property()
   public sendEmail?: boolean;
 
-  @Payment.property()
+  @Payment.property({type: Invoice})
   public invoice?: Invoice | null;
 
-  @Payment.property()
+  @Payment.property({type: User})
   public paymentRecorder?: User | null;
 }

--- a/typescript/src/entities/phone_number.ts
+++ b/typescript/src/entities/phone_number.ts
@@ -7,7 +7,7 @@ export class PhoneNumber extends Entity {
   protected static singularName: string = "phoneNumber";
   protected static pluralName: string = "phoneNumbers";
 
-  @PhoneNumber.property()
+  @PhoneNumber.property({type: Date})
   public archived?: Date | null;
 
   @PhoneNumber.property()

--- a/typescript/src/entities/product.ts
+++ b/typescript/src/entities/product.ts
@@ -17,7 +17,7 @@ export class Product extends Entity {
   protected static singularName: string = "product";
   protected static pluralName: string = "products";
 
-  @Product.property()
+  @Product.property({type: Date})
   public archived?: Date | null;
 
   @Product.property()
@@ -35,25 +35,25 @@ export class Product extends Entity {
   @Product.property()
   public unitPrice?: number;
 
-  @Product.property()
+  @Product.property({type: Number})
   public unitWeight?: number | null;
 
-  @Product.property()
+  @Product.property({type: Number})
   public unitHeight?: number | null;
 
-  @Product.property()
+  @Product.property({type: Number})
   public unitWidth?: number | null;
 
-  @Product.property()
+  @Product.property({type: Number})
   public unitDepth?: number | null;
 
   @Product.property()
   public name?: string;
 
-  @Product.property()
+  @Product.property({type: String})
   public description?: string | null;
 
-  @Product.property()
+  @Product.property({type: String})
   public notes?: string | null;
 
   @Product.property()
@@ -113,7 +113,7 @@ export class Product extends Entity {
   @Product.property({arrayType: "DomainTag"})
   public tags?: Array<DomainTag>;
 
-  @Product.property()
+  @Product.property({type: MerchiFile})
   public featureImage?: MerchiFile | null;
 
   @Product.property({arrayType: "Company", jsonName: "saved_by_companies"})

--- a/typescript/src/entities/production_comment.ts
+++ b/typescript/src/entities/production_comment.ts
@@ -9,13 +9,13 @@ export class ProductionComment extends Entity {
   protected static singularName: string = "productionComment";
   protected static pluralName: string = "productionComments";
 
-  @ProductionComment.property()
+  @ProductionComment.property({type: Date})
   public archived?: Date | null;
 
   @ProductionComment.property()
   public id?: number;
 
-  @ProductionComment.property()
+  @ProductionComment.property({type: Date})
   public date?: Date | null;
 
   @ProductionComment.property()
@@ -33,7 +33,7 @@ export class ProductionComment extends Entity {
   @ProductionComment.property()
   public sendEmail?: boolean;
 
-  @ProductionComment.property()
+  @ProductionComment.property({type: MerchiFile})
   public file?: MerchiFile | null;
 
   @ProductionComment.property()

--- a/typescript/src/entities/session.ts
+++ b/typescript/src/entities/session.ts
@@ -8,21 +8,21 @@ export class Session extends Entity {
   protected static pluralName: string = "sessions";
   protected static primaryKey: string = "token";
 
-  @Session.property()
+  @Session.property({type: Date})
   public archived?: Date | null;
 
-  @Session.property()
+  @Session.property({type: String})
   public ip?: string | null;
 
   @Session.property()
   public token?: string;
 
-  @Session.property()
+  @Session.property({type: Boolean})
   public remember?: boolean | null;
 
   @Session.property()
   public user?: User;
 
-  @Session.property()
+  @Session.property({type: Domain})
   public domain?: Domain | null;
 }

--- a/typescript/src/entities/shipment.ts
+++ b/typescript/src/entities/shipment.ts
@@ -13,52 +13,52 @@ export class Shipment extends Entity {
   protected static singularName: string = "shipment";
   protected static pluralName: string = "shipments";
 
-  @Shipment.property()
+  @Shipment.property({type: Date})
   public archived?: Date | null;
 
   @Shipment.property()
   public id?: number;
 
-  @Shipment.property()
+  @Shipment.property({type: Date})
   public creationDate?: Date | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Date})
   public dispatchedDate?: Date | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Date})
   public dispatchDate?: Date | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Date})
   public expectedReceiveDate?: Date | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Date})
   public receivedDate?: Date | null;
 
   @Shipment.property()
   public senderResponsible?: boolean;
 
-  @Shipment.property()
+  @Shipment.property({type: String})
   public senderNotes?: string | null;
 
-  @Shipment.property()
+  @Shipment.property({type: String})
   public receiverNotes?: string | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Number})
   public transportCompany?: number | null;
 
-  @Shipment.property()
+  @Shipment.property({type: String})
   public trackingNumber?: string | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Number})
   public cost?: number | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Number})
   public taxAmount?: number | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Number})
   public maxWeight?: number | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Number})
   public maxVolume?: number | null;
 
   @Shipment.property()
@@ -67,28 +67,28 @@ export class Shipment extends Entity {
   @Shipment.property()
   public sendEmail?: boolean;
 
-  @Shipment.property()
+  @Shipment.property({type: CountryTax})
   public taxType?: CountryTax | null;
 
-  @Shipment.property()
+  @Shipment.property({type: User})
   public sender?: User | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Company})
   public senderCompany?: Company | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Address})
   public senderAddress?: Address | null;
 
-  @Shipment.property()
+  @Shipment.property({type: User})
   public receiver?: User | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Company})
   public receiverCompany?: Company | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Address})
   public receiverAddress?: Address | null;
 
-  @Shipment.property()
+  @Shipment.property({type: Invoice})
   public invoice?: Invoice | null;
 
   @Shipment.property({arrayType: "DomainTag"})

--- a/typescript/src/entities/short_url.ts
+++ b/typescript/src/entities/short_url.ts
@@ -7,7 +7,7 @@ export class ShortUrl extends Entity {
   protected static singularName: string = "shortUrl";
   protected static pluralName: string = "shortUrls";
 
-  @ShortUrl.property()
+  @ShortUrl.property({type: Date})
   public archived?: Date | null;
 
   @ShortUrl.property()
@@ -25,10 +25,10 @@ export class ShortUrl extends Entity {
   @ShortUrl.property()
   public triedTimes?: number;
 
-  @ShortUrl.property()
+  @ShortUrl.property({type: Date})
   public lastLookup?: Date | null;
 
-  @ShortUrl.property()
+  @ShortUrl.property({type: User})
   public user?: User | null;
 
   @ShortUrl.property({arrayType: "Notification"})

--- a/typescript/src/entities/supply_domain.ts
+++ b/typescript/src/entities/supply_domain.ts
@@ -7,7 +7,7 @@ export class SupplyDomain extends Entity {
   protected static singularName: string = "supplyDomain";
   protected static pluralName: string = "supplyDomains";
 
-  @SupplyDomain.property()
+  @SupplyDomain.property({type: Date})
   public archived?: Date | null;
 
   @SupplyDomain.property()
@@ -16,7 +16,7 @@ export class SupplyDomain extends Entity {
   @SupplyDomain.property()
   public product?: Product;
 
-  @SupplyDomain.property()
+  @SupplyDomain.property({type: Product})
   public supplyProduct?: Product | null;
 
   @SupplyDomain.property()

--- a/typescript/src/entities/theme.ts
+++ b/typescript/src/entities/theme.ts
@@ -9,7 +9,7 @@ export class Theme extends Entity {
   protected static singularName: string = "theme";
   protected static pluralName: string = "themes";
 
-  @Theme.property()
+  @Theme.property({type: Date})
   public archived?: Date | null;
 
   @Theme.property()
@@ -18,13 +18,13 @@ export class Theme extends Entity {
   @Theme.property()
   public mainCssStatus?: number;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public mainCssErrorMessage?: string | null;
 
   @Theme.property()
   public emailCssStatus?: number;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public emailCssErrorMessage?: string | null;
 
   @Theme.property()
@@ -36,7 +36,7 @@ export class Theme extends Entity {
   @Theme.property()
   public headerTemplate?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public headerError?: string | null;
 
   @Theme.property()
@@ -48,7 +48,7 @@ export class Theme extends Entity {
   @Theme.property()
   public footerTemplate?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public footerError?: string | null;
 
   @Theme.property()
@@ -60,7 +60,7 @@ export class Theme extends Entity {
   @Theme.property()
   public indexPageTemplate?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public indexPageError?: string | null;
 
   @Theme.property()
@@ -72,7 +72,7 @@ export class Theme extends Entity {
   @Theme.property()
   public invoicesPageTemplate?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public invoicesPageError?: string | null;
 
   @Theme.property()
@@ -84,7 +84,7 @@ export class Theme extends Entity {
   @Theme.property()
   public productsPageTemplate?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public productsPageError?: string | null;
 
   @Theme.property()
@@ -93,10 +93,10 @@ export class Theme extends Entity {
   @Theme.property()
   public productsJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public domainInvitePageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public domainInvitePageError?: string | null;
 
   @Theme.property()
@@ -105,10 +105,10 @@ export class Theme extends Entity {
   @Theme.property()
   public domainInviteJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public resetPasswordPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public resetPasswordPageError?: string | null;
 
   @Theme.property()
@@ -117,10 +117,10 @@ export class Theme extends Entity {
   @Theme.property()
   public passwordResetJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public passwordChangePageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public passwordChangePageError?: string | null;
 
   @Theme.property()
@@ -129,10 +129,10 @@ export class Theme extends Entity {
   @Theme.property()
   public passwordChangeJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public smsLoginPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public smsLoginPageError?: string | null;
 
   @Theme.property()
@@ -141,10 +141,10 @@ export class Theme extends Entity {
   @Theme.property()
   public smsLoginJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public smsTokenPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public smsTokenPageError?: string | null;
 
   @Theme.property()
@@ -153,10 +153,10 @@ export class Theme extends Entity {
   @Theme.property()
   public smsTokenJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public jobsPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public jobsPageError?: string | null;
 
   @Theme.property()
@@ -165,10 +165,10 @@ export class Theme extends Entity {
   @Theme.property()
   public jobsJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public jobDraftingPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public jobDraftingPageError?: string | null;
 
   @Theme.property()
@@ -177,10 +177,10 @@ export class Theme extends Entity {
   @Theme.property()
   public jobDraftingJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public jobQuoteRequestedPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public jobQuoteRequestedPageError?: string | null;
 
   @Theme.property()
@@ -189,10 +189,10 @@ export class Theme extends Entity {
   @Theme.property()
   public jobQuoteRequestedJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public draftPreviewPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public draftPreviewPageError?: string | null;
 
   @Theme.property()
@@ -201,10 +201,10 @@ export class Theme extends Entity {
   @Theme.property()
   public draftPreviewJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public invoicePageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public invoicePageError?: string | null;
 
   @Theme.property()
@@ -213,10 +213,10 @@ export class Theme extends Entity {
   @Theme.property()
   public invoiceJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public userProfilePageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public userProfilePageError?: string | null;
 
   @Theme.property()
@@ -225,10 +225,10 @@ export class Theme extends Entity {
   @Theme.property()
   public userProfileJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public companyProfilePageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public companyProfilePageError?: string | null;
 
   @Theme.property()
@@ -237,10 +237,10 @@ export class Theme extends Entity {
   @Theme.property()
   public companyProfileJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public productPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public productPageError?: string | null;
 
   @Theme.property()
@@ -249,10 +249,10 @@ export class Theme extends Entity {
   @Theme.property()
   public productJs?: string;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public invoicePaidPageTemplate?: string | null;
 
-  @Theme.property()
+  @Theme.property({type: String})
   public invoicePaidPageError?: string | null;
 
   @Theme.property()
@@ -267,34 +267,34 @@ export class Theme extends Entity {
   @Theme.property()
   public public?: boolean;
 
-  @Theme.property({embeddedByDefault: false})
+  @Theme.property({embeddedByDefault: false, type: String})
   public mainCss?: string | null;
 
-  @Theme.property({embeddedByDefault: false})
+  @Theme.property({embeddedByDefault: false, type: String})
   public mainCssTemplateUsing?: string | null;
 
-  @Theme.property({embeddedByDefault: false})
+  @Theme.property({embeddedByDefault: false, type: String})
   public mainCssTemplateEditing?: string | null;
 
-  @Theme.property({embeddedByDefault: false})
+  @Theme.property({embeddedByDefault: false, type: String})
   public emailCss?: string | null;
 
-  @Theme.property({embeddedByDefault: false})
+  @Theme.property({embeddedByDefault: false, type: String})
   public emailCssTemplateUsing?: string | null;
 
-  @Theme.property({embeddedByDefault: false})
+  @Theme.property({embeddedByDefault: false, type: String})
   public emailCssTemplateEditing?: string | null;
 
   @Theme.property({arrayType: "MerchiFile"})
   public cssImageFiles?: Array<MerchiFile>;
 
-  @Theme.property()
+  @Theme.property({type: MerchiFile})
   public featureImage?: MerchiFile | null;
 
-  @Theme.property()
+  @Theme.property({type: 'Domain'})
   public domain?: Domain | null;
 
-  @Theme.property()
+  @Theme.property({type: User})
   public author?: User | null;
 
   @Theme.property({arrayType: "MerchiFile"})

--- a/typescript/src/entities/user.ts
+++ b/typescript/src/entities/user.ts
@@ -31,7 +31,7 @@ export class User extends Entity {
   protected static singularName: string = 'user';
   protected static pluralName: string = 'users';
 
-  @User.property()
+  @User.property({type: Date})
   public archived?: Date | null;
 
   @User.property()
@@ -40,28 +40,28 @@ export class User extends Entity {
   @User.property()
   public isSuperUser?: boolean;
 
-  @User.property()
+  @User.property({type: String})
   public password?: string | null;
 
-  @User.property()
+  @User.property({type: String})
   public salt?: string | null;
 
-  @User.property()
+  @User.property({type: String})
   public facebookUserId?: string | null;
 
-  @User.property()
+  @User.property({type: String})
   public resetToken?: string | null;
 
-  @User.property()
+  @User.property({type: String})
   public resetTokenDate?: Date | null;
 
-  @User.property()
+  @User.property({type: String})
   public smsToken?: string | null;
 
-  @User.property()
+  @User.property({type: Date})
   public resetSmsTokenDate?: Date | null;
 
-  @User.property()
+  @User.property({type: String})
   public smsClientToken?: string | null;
 
   @User.property()
@@ -76,22 +76,22 @@ export class User extends Entity {
   @User.property()
   public enableClientEmails?: boolean;
 
-  @User.property()
+  @User.property({type: String})
   public clientToken?: string | null;
 
   @User.property()
   public name?: string;
 
-  @User.property()
+  @User.property({type: String})
   public comments?: string | null;
 
-  @User.property()
+  @User.property({type: String})
   public timezone?: string | null;
 
-  @User.property()
+  @User.property({type: Date})
   public created?: Date | null;
 
-  @User.property()
+  @User.property({type: String})
   public preferredLanguage?: string | null;
 
   @User.property()
@@ -118,7 +118,7 @@ export class User extends Entity {
   @User.property({ arrayType: 'Product' })
   public products?: Array<Product>;
 
-  @User.property()
+  @User.property({type: 'MerchiFile'})
   public profilePicture?: MerchiFile | null;
 
   @User.property({ arrayType: 'PhoneNumber' })

--- a/typescript/src/entities/user_company.ts
+++ b/typescript/src/entities/user_company.ts
@@ -7,21 +7,21 @@ export class UserCompany extends Entity {
   protected static singularName: string = "userCompany";
   protected static pluralName: string = "userCompanies";
 
-  @UserCompany.property()
+  @UserCompany.property({type: Date})
   public archived?: Date | null;
 
   @UserCompany.property()
   public id?: number;
 
-  @UserCompany.property()
+  @UserCompany.property({type: Boolean})
   public main?: boolean | null;
 
   @UserCompany.property()
   public isAdmin?: boolean;
 
-  @UserCompany.property()
+  @UserCompany.property({type: User})
   public user?: User | null;
 
-  @UserCompany.property()
+  @UserCompany.property({type: Company})
   public company?: Company | null;
 }

--- a/typescript/src/entities/variation.ts
+++ b/typescript/src/entities/variation.ts
@@ -11,13 +11,13 @@ export class Variation extends Entity {
   protected static singularName: string = "variation";
   protected static pluralName: string = "variations";
 
-  @Variation.property()
+  @Variation.property({type: Date})
   public archived?: Date | null;
 
   @Variation.property()
   public id?: number;
 
-  @Variation.property()
+  @Variation.property({type: String})
   public value?: string | null;
 
   @Variation.property()
@@ -38,13 +38,13 @@ export class Variation extends Entity {
   @Variation.property()
   public variationField?: VariationField;
 
-  @Variation.property()
+  @Variation.property({type: VariationsGroup})
   public variationsGroup?: VariationsGroup | null;
 
-  @Variation.property()
+  @Variation.property({type: Job})
   public job?: Job | null;
 
-  @Variation.property()
+  @Variation.property({type: CartItem})
   public cartItem?: CartItem | null;
 
   @Variation.property({arrayType: "MerchiFile"})

--- a/typescript/src/entities/variation_field.ts
+++ b/typescript/src/entities/variation_field.ts
@@ -10,7 +10,7 @@ export class VariationField extends Entity {
   protected static singularName: string = "variationField";
   protected static pluralName: string = "variationFields";
 
-  @VariationField.property()
+  @VariationField.property({type: Date})
   public archived?: Date | null;
 
   @VariationField.property()
@@ -28,7 +28,7 @@ export class VariationField extends Entity {
   @VariationField.property()
   public name?: string;
 
-  @VariationField.property()
+  @VariationField.property({type: String})
   public placeholder?: string | null;
 
   @VariationField.property()
@@ -43,10 +43,10 @@ export class VariationField extends Entity {
   @VariationField.property()
   public rows?: number;
 
-  @VariationField.property()
+  @VariationField.property({type: Number})
   public fieldMin?: number | null;
 
-  @VariationField.property()
+  @VariationField.property({type: Number})
   public fieldMax?: number | null;
 
   @VariationField.property()
@@ -82,10 +82,10 @@ export class VariationField extends Entity {
   @VariationField.property({arrayType: "Variation"})
   public variations?: Array<Variation>;
 
-  @VariationField.property()
+  @VariationField.property({type: Product})
   public productGroupBackref?: Product | null;
 
-  @VariationField.property()
+  @VariationField.property({type: Product})
   public productIndependentBackref?: Product | null;
 
   @VariationField.property({arrayType: "VariationFieldsOption"})

--- a/typescript/src/entities/variation_fields_option.ts
+++ b/typescript/src/entities/variation_fields_option.ts
@@ -9,16 +9,16 @@ export class VariationFieldsOption extends Entity {
   protected static singularName: string = "variationFieldsOption";
   protected static pluralName: string = "variationFieldsOptions";
 
-  @VariationFieldsOption.property()
+  @VariationFieldsOption.property({type: Date})
   public archived?: Date | null;
 
   @VariationFieldsOption.property()
   public id?: number;
 
-  @VariationFieldsOption.property()
+  @VariationFieldsOption.property({type: String})
   public value?: string | null;
 
-  @VariationFieldsOption.property()
+  @VariationFieldsOption.property({type: String})
   public colour?: string | null;
 
   @VariationFieldsOption.property()
@@ -33,10 +33,10 @@ export class VariationFieldsOption extends Entity {
   @VariationFieldsOption.property()
   public variationUnitCost?: number;
 
-  @VariationFieldsOption.property()
+  @VariationFieldsOption.property({type: VariationField})
   public variationField?: VariationField | null;
 
-  @VariationFieldsOption.property()
+  @VariationFieldsOption.property({type: MerchiFile})
   public linkedFile?: MerchiFile | null;
 
   @VariationFieldsOption.property({arrayType: "Variation"})

--- a/typescript/src/entities/variations_group.ts
+++ b/typescript/src/entities/variations_group.ts
@@ -9,7 +9,7 @@ export class VariationsGroup extends Entity {
   protected static singularName: string = "variationsGroup";
   protected static pluralName: string = "variationsGroups";
 
-  @VariationsGroup.property()
+  @VariationsGroup.property({type: Date})
   public archived?: Date | null;
 
   @VariationsGroup.property()
@@ -18,16 +18,16 @@ export class VariationsGroup extends Entity {
   @VariationsGroup.property()
   public quantity?: number;
 
-  @VariationsGroup.property()
+  @VariationsGroup.property({type: Number})
   public groupCost?: number | null;
 
-  @VariationsGroup.property()
+  @VariationsGroup.property({type: Job})
   public job?: Job | null;
 
-  @VariationsGroup.property()
+  @VariationsGroup.property({type: CartItem})
   public cartItem?: CartItem | null;
 
-  @VariationsGroup.property()
+  @VariationsGroup.property({type: Inventory})
   public inventory?: Inventory | null;
 
   @VariationsGroup.property({arrayType: "Variation"})

--- a/typescript/src/entity.ts
+++ b/typescript/src/entity.ts
@@ -17,6 +17,7 @@ function toUnixTimestamp(date: Date) {
 interface PropertyOptions {
   embeddedByDefault?: boolean;
   jsonName?: string;
+  type?: any;
   arrayType?: string;
 }
 
@@ -190,9 +191,27 @@ export class Entity {
         propertyType.prototype instanceof Entity);
       const embeddedByDefault = options.embeddedByDefault !== undefined ?
         options.embeddedByDefault : normallyEmbeddedByDefault;
+      let type;
+      if (options.type === undefined) {
+        type = propertyType;
+      } else {
+        type = options.type;
+        if (typeof type === 'string') {
+          type = self.getEntityClass(type);
+        }
+        type = self.merchi.setupClass(type);
+      }
+      /* istanbul ignore next */
+      if (type === Object) {
+        /* istanbul ignore next */
+        const resource = (self.constructor as typeof Entity).resourceName;
+        const err = 'Bad attribute type ' +
+          `${resource}.${attributeName}: ${type}`;
+        throw new Error(err);
+      }
       const propertyInfo = {property: jsonName,
         attribute: attributeName,
-        type: propertyType,
+        type: type,
         arrayType: realArrayType,
         embeddedByDefault: embeddedByDefault,
         dirty: true};

--- a/typescript/src/merchi.ts
+++ b/typescript/src/merchi.ts
@@ -124,92 +124,84 @@ export class Merchi {
   public Component: typeof Component;
   public BidItem: typeof BidItem;
 
+  public setupClass(cls: typeof Entity) {
+    const result = cloneClass(cls, this) as typeof Entity;
+    result.merchi = this;
+    return result;
+  }
+
   constructor(sessionToken?: string) {
     if (sessionToken) {
       this.sessionToken = sessionToken;
     } else {
       this.sessionToken = getCookie('session_token');
     }
-    function setupClass(merchi: Merchi, cls: typeof Entity) {
-      // copy, to prevent interference from other merchi sessions
-      const result = cloneClass(cls, merchi) as typeof Entity;
-      result.merchi = merchi;
-      return result;
-    }
+
     // re-export configured versions of all classes
-    this.Variation = setupClass(this, Variation) as typeof Variation;
-    this.DraftComment = setupClass(this, DraftComment) as typeof DraftComment;
-    this.Component = setupClass(this, Component) as typeof Component;
-    this.Theme = setupClass(this, Theme) as typeof Theme;
-    this.Company = setupClass(this, Company) as typeof Company;
-    this.MenuItem = setupClass(this, MenuItem) as typeof MenuItem;
-    this.Inventory = setupClass(this, Inventory) as typeof Inventory;
-    this.Notification = setupClass(this, Notification) as typeof Notification;
-    this.Shipment = setupClass(this, Shipment) as typeof Shipment;
-    this.Domain = setupClass(this, Domain) as typeof Domain;
-    this.Invoice = setupClass(this, Invoice) as typeof Invoice;
-    this.Job = setupClass(this, Job) as typeof Job;
-    this.ComponentTag = setupClass(this, ComponentTag) as typeof ComponentTag;
-    this.Category = setupClass(this, Category) as typeof Category;
-    this.VariationField = setupClass(
-      this,
+    this.Variation = this.setupClass(Variation) as typeof Variation;
+    this.DraftComment = this.setupClass(DraftComment) as typeof DraftComment;
+    this.Component = this.setupClass(Component) as typeof Component;
+    this.Theme = this.setupClass(Theme) as typeof Theme;
+    this.Company = this.setupClass(Company) as typeof Company;
+    this.MenuItem = this.setupClass(MenuItem) as typeof MenuItem;
+    this.Inventory = this.setupClass(Inventory) as typeof Inventory;
+    this.Notification = this.setupClass(Notification) as typeof Notification;
+    this.Shipment = this.setupClass(Shipment) as typeof Shipment;
+    this.Domain = this.setupClass(Domain) as typeof Domain;
+    this.Invoice = this.setupClass(Invoice) as typeof Invoice;
+    this.Job = this.setupClass(Job) as typeof Job;
+    this.ComponentTag = this.setupClass(ComponentTag) as typeof ComponentTag;
+    this.Category = this.setupClass(Category) as typeof Category;
+    this.VariationField = this.setupClass(
       VariationField
     ) as typeof VariationField;
-    this.InventoryUnitVariation = setupClass(
-      this,
+    this.InventoryUnitVariation = this.setupClass(
       InventoryUnitVariation
     ) as typeof InventoryUnitVariation;
-    this.PhoneNumber = setupClass(this, PhoneNumber) as typeof PhoneNumber;
-    this.BidItem = setupClass(this, BidItem) as typeof BidItem;
-    this.Menu = setupClass(this, Menu) as typeof Menu;
-    this.Assignment = setupClass(this, Assignment) as typeof Assignment;
-    this.Draft = setupClass(this, Draft) as typeof Draft;
-    this.VariationsGroup = setupClass(
-      this,
+    this.PhoneNumber = this.setupClass(PhoneNumber) as typeof PhoneNumber;
+    this.BidItem = this.setupClass(BidItem) as typeof BidItem;
+    this.Menu = this.setupClass(Menu) as typeof Menu;
+    this.Assignment = this.setupClass(Assignment) as typeof Assignment;
+    this.Draft = this.setupClass(Draft) as typeof Draft;
+    this.VariationsGroup = this.setupClass(
       VariationsGroup
     ) as typeof VariationsGroup;
-    this.EnrolledDomain = setupClass(
-      this,
+    this.EnrolledDomain = this.setupClass(
       EnrolledDomain
     ) as typeof EnrolledDomain;
-    this.CompanyInvitation = setupClass(
-      this,
+    this.CompanyInvitation = this.setupClass(
       CompanyInvitation
     ) as typeof CompanyInvitation;
-    this.Bid = setupClass(this, Bid) as typeof Bid;
-    this.EmailAddress = setupClass(this, EmailAddress) as typeof EmailAddress;
-    this.ProductionComment = setupClass(
-      this,
+    this.Bid = this.setupClass(Bid) as typeof Bid;
+    this.EmailAddress = this.setupClass(EmailAddress) as typeof EmailAddress;
+    this.ProductionComment = this.setupClass(
       ProductionComment
     ) as typeof ProductionComment;
-    this.Backup = setupClass(this, Backup) as typeof Backup;
-    this.CountryTax = setupClass(this, CountryTax) as typeof CountryTax;
-    this.ShortUrl = setupClass(this, ShortUrl) as typeof ShortUrl;
-    this.Product = setupClass(this, Product) as typeof Product;
-    this.SystemRole = setupClass(this, SystemRole) as typeof SystemRole;
-    this.CartItem = setupClass(this, CartItem) as typeof CartItem;
-    this.UserCompany = setupClass(this, UserCompany) as typeof UserCompany;
-    this.DomainTag = setupClass(this, DomainTag) as typeof DomainTag;
-    this.VariationFieldsOption = setupClass(
-      this,
+    this.Backup = this.setupClass(Backup) as typeof Backup;
+    this.CountryTax = this.setupClass(CountryTax) as typeof CountryTax;
+    this.ShortUrl = this.setupClass(ShortUrl) as typeof ShortUrl;
+    this.Product = this.setupClass(Product) as typeof Product;
+    this.SystemRole = this.setupClass(SystemRole) as typeof SystemRole;
+    this.CartItem = this.setupClass(CartItem) as typeof CartItem;
+    this.UserCompany = this.setupClass(UserCompany) as typeof UserCompany;
+    this.DomainTag = this.setupClass(DomainTag) as typeof DomainTag;
+    this.VariationFieldsOption = this.setupClass(
       VariationFieldsOption
     ) as typeof VariationFieldsOption;
-    this.Address = setupClass(this, Address) as typeof Address;
-    this.Item = setupClass(this, Item) as typeof Item;
-    this.SupplyDomain = setupClass(this, SupplyDomain) as typeof SupplyDomain;
-    this.DomainInvitation = setupClass(
-      this,
-      DomainInvitation
+    this.Address = this.setupClass(Address) as typeof Address;
+    this.Item = this.setupClass(Item) as typeof Item;
+    this.SupplyDomain = this.setupClass(SupplyDomain) as typeof SupplyDomain;
+    this.DomainInvitation = this.setupClass(DomainInvitation
     ) as typeof DomainInvitation;
-    this.EmailCounter = setupClass(this, EmailCounter) as typeof EmailCounter;
-    this.Session = setupClass(this, Session) as typeof Session;
-    this.Bank = setupClass(this, Bank) as typeof Bank;
-    this.Discount = setupClass(this, Discount) as typeof Discount;
-    this.Payment = setupClass(this, Payment) as typeof Payment;
-    this.Cart = setupClass(this, Cart) as typeof Cart;
-    this.MerchiFile = setupClass(this, MerchiFile) as typeof MerchiFile;
-    this.User = setupClass(this, User) as typeof User;
-    this.JobComment = setupClass(this, JobComment) as typeof JobComment;
+    this.EmailCounter = this.setupClass(EmailCounter) as typeof EmailCounter;
+    this.Session = this.setupClass(Session) as typeof Session;
+    this.Bank = this.setupClass(Bank) as typeof Bank;
+    this.Discount = this.setupClass(Discount) as typeof Discount;
+    this.Payment = this.setupClass(Payment) as typeof Payment;
+    this.Cart = this.setupClass(Cart) as typeof Cart;
+    this.MerchiFile = this.setupClass(MerchiFile) as typeof MerchiFile;
+    this.User = this.setupClass(User) as typeof User;
+    this.JobComment = this.setupClass(JobComment) as typeof JobComment;
   }
 
   public authenticatedFetch = (resource: string, options: RequestOptions) => {


### PR DESCRIPTION
Since ts does not setup type metadata properly in the cases of recursive
imports and union types, require sdk author to manually specify duplicate
runtime type information for those cases.