### PR TITLE
enable s3 acceleration

### DIFF
--- a/python/util/s3.py
+++ b/python/util/s3.py
@@ -4,6 +4,8 @@ import requests
 import boto3
 import s3fs
 
+from botocore.config import Config
+
 URL_TTL = 14400  # (seconds = 4 hours)
 
 
@@ -15,9 +17,10 @@ class S3Bucket(object):
         # contrary to the documentation, the smallest chunk size that S3 allows,
         # other than for the last chunk, is 5MiB, not 5MB
         self.chunk_size = 5242880
+        config = Config(s3={"use_accelerate_endpoint": True})
         self.session = boto3.Session(aws_access_key_id=access_key,
                                      aws_secret_access_key=secret_key)
-        self.s3 = self.session.resource('s3')
+        self.s3 = self.session.resource('s3', config=config)
         self.bucket = self.s3.Bucket(bucket_name)
         self.bucket_name = bucket_name
         self.client = self.s3.meta.client


### PR DESCRIPTION
have enabled aws s3 acceleration service which utilised aws CDN service as the edge caching
for dev, staging, prod bucket

"should" have experience a significant speed improvement on file upload and download