### PR TITLE
feat: add optional details field to ApiError

### DIFF
--- a/python/util/api_error.py
+++ b/python/util/api_error.py
@@ -3,12 +3,27 @@ import json
 
 class ApiError(Exception):
 
-    def __init__(self, message, status_code, error_code, debug_message=None):
+    def __init__(
+        self,
+        message,
+        status_code,
+        error_code,
+        debug_message=None,
+        details=None,
+    ):
         Exception.__init__(self, message)
         self.message = message
         self.status_code = status_code
         self.error_code = error_code
         self.debug_message = debug_message
+        # ``details`` is an optional JSON-serializable dict of structured
+        # context about the error (e.g. the entity id that was missing
+        # and the fields the client sent for it). It is surfaced in the
+        # error response when non-None, alongside the existing
+        # ``message``/``statusCode``/``errorCode`` keys. Existing
+        # callers that do not pass ``details`` see no change in
+        # behaviour or response shape.
+        self.details = details
 
     def __repr__(self):
         return json.dumps(self.to_dict(), indent=4)
@@ -17,6 +32,9 @@ class ApiError(Exception):
         return self.__repr__()
 
     def to_dict(self):
-        return {'message': self.message,
-                'status_code': self.status_code,
-                'error_code': self.error_code}
+        result = {'message': self.message,
+                  'status_code': self.status_code,
+                  'error_code': self.error_code}
+        if self.details is not None:
+            result['details'] = self.details
+        return result


### PR DESCRIPTION
ApiError gains an optional `details` kwarg for structured, JSON-serializable context (e.g. the missing entity's id and the fields the client sent for it). It is surfaced in `to_dict` only when non-None, so existing callers are unchanged.

Consumed by merchi_api backend/error.py::error_response to append a `details` key to error responses. Paired with a merchi_api change that enriches the `no such <rel>` errors in Base.fill_relationship.

Made-with: Cursor