### PR TITLE
Handle pycountry LookupError in address_country

### DIFF
--- a/python/util/address_util.py
+++ b/python/util/address_util.py
@@ -5,7 +5,12 @@ def address_country(code):
     """ Take a 2 char country code like 'AU' and return the associated country
         name, i.e. 'Australia' as a string
     """
-    country_name = pycountry.countries.get(alpha_2=code)
+    if not code:
+        return ''
+    try:
+        country_name = pycountry.countries.get(alpha_2=code)
+    except (KeyError, LookupError):
+        return ''
     if not country_name:
         return ''
     return country_name.name


### PR DESCRIPTION
## Summary
- Newer `pycountry` raises `LookupError` from `countries.get()` for unknown codes (e.g. legacy `ZZ`), which crashed domain client CSV export and other address formatting callers.
- Catch `LookupError`/`KeyError` and return an empty string for invalid or missing codes.

## Test plan
- [ ] Call `address_country("AU")` → `"Australia"`
- [ ] Call `address_country("ZZ")` / `address_country(None)` → `""` (no exception)


Made with [Cursor](https://cursor.com)