### PR TITLE
Remove unused Product.ai_context_drafting

### DIFF
--- a/python/products.py
+++ b/python/products.py
@@ -29,7 +29,6 @@ class Product(sdk.python.entities.Entity):
     country = Property(str)
     currency = Property(str)
     description = Property(str)
-    ai_context_drafting = Property(str)
     shopify_product_id = Property(str)
     sp_product_id = Property(str)
     unit_price = Property(float)


### PR DESCRIPTION
## Summary
- Drop `Product.ai_context_drafting` from the Python SDK.
- Draft placement rules now belong in product skills and playground extra instructions, not this unused product field.

## Test plan
- [ ] Product load/save still works without `ai_context_drafting`
- [ ] No remaining Python SDK references to `ai_context_drafting`